### PR TITLE
Added Bearer to Authorization header

### DIFF
--- a/api/sendpulse_api.rb
+++ b/api/sendpulse_api.rb
@@ -114,7 +114,7 @@ class SendpulseApi
     http.use_ssl = true if @protocol == 'https'
 
     token = {}
-    token.merge!( 'authorization' => @token ) if use_token
+    token.merge!( 'Authorization' => "Bearer #{@token}" ) if use_token
 
     case method
       when 'POST'


### PR DESCRIPTION
Authorized requests will only work with the Bearer (https://sendpulse.com/integrations/api#auth)